### PR TITLE
Replace chrome-gnome-shell with gnome-browser-connector

### DIFF
--- a/apps/packages/aur.txt
+++ b/apps/packages/aur.txt
@@ -1,11 +1,11 @@
 ananicy-cpp
 ananicy-rules-git
 bottles
-chrome-gnome-shell
 downgrade
 duckstation-qt-bin
 extramaus
 firefox-pwa-bin
+gnome-browser-connector
 gnome-shell-extension-application-volume-mixer
 gnome-shell-extension-arch-update
 gnome-shell-extension-bluetooth-quick-connect


### PR DESCRIPTION
Gnome made their own connector available on AUR here https://aur.archlinux.org/packages/gnome-browser-connector, so we can now replace chrome-gnome-shell with it.

I don't know why zenstates-git show a diff but I didn't change anything there.