### PR TITLE
Enable amd_pstate on linux kernel 6.3 and newer

### DIFF
--- a/hardware/amd/ryzen.nix
+++ b/hardware/amd/ryzen.nix
@@ -2,8 +2,7 @@
 
 lib.mkIf config.amd.cpu.enable {
   boot = lib.mkMerge [
-    # Needed for zenstates
-    { kernelModules = [ "msr" ]; }
+    { kernelModules = [ "msr" ]; } # Needed for zenstates
 
     # for older kernels, see https://github.com/NixOS/nixos-hardware/blob/c256df331235ce369fdd49c00989fdaa95942934/common/cpu/amd/pstate.nix
     (lib.mkIf (lib.versionAtLeast config.boot.kernelPackages.kernel.version "6.3") {

--- a/hardware/amd/ryzen.nix
+++ b/hardware/amd/ryzen.nix
@@ -1,7 +1,15 @@
 { pkgs, lib, config, ... }:
 
 lib.mkIf config.amd.cpu.enable {
-  boot.kernelModules = [ "msr" ]; # Needed for zenstates
+  boot = lib.mkMerge [
+    # Needed for zenstates
+    { kernelModules = [ "msr" ]; }
+
+    # for older kernels, see https://github.com/NixOS/nixos-hardware/blob/c256df331235ce369fdd49c00989fdaa95942934/common/cpu/amd/pstate.nix
+    (lib.mkIf (lib.versionAtLeast config.boot.kernelPackages.kernel.version "6.3") {
+      kernelParams = [ "amd_pstate=active" ];
+    })
+  ];
 
   hardware.cpu.amd.updateMicrocode = true;
 


### PR DESCRIPTION
NixOS doesn't enable amd_pstate by default on linux kernel 6.3 and 6.4, so we set it manually. We can probably remove this when 6.5 or 6.6 rolls in.

To check if you're actually using it, `rebuild`, restart and run:
```nix
nix-shell -p linuxKernel.packages.linux_zen.cpupower                                                                                                                                          
cpupower frequency-info
```

You should see:
![image](https://github.com/IceDBorn/IceDOS/assets/40207026/77cae363-dce0-465f-bc76-5193955fb3c6)

You can also run `dmesg | grep pstate` and see if you get any results.