### PR TITLE
Use default nixos video drivers for x11

### DIFF
--- a/hardware/amd/radeon.nix
+++ b/hardware/amd/radeon.nix
@@ -3,8 +3,6 @@
 lib.mkIf config.amd.gpu.enable {
   boot.initrd.kernelModules = [ "amdgpu" ]; # Use the amdgpu drivers upon boot
 
-  services.xserver.videoDrivers = [ "amdgpu" ];
-
   programs.corectrl = {
     enable = true;
     gpuOverclock = {
@@ -15,14 +13,14 @@ lib.mkIf config.amd.gpu.enable {
 
   # Do not ask for password when launching corectrl
   security.polkit.extraConfig = ''
-    polkit.addRule(function(action, subject) {
-    if ((action.id == "org.corectrl.helper.init" ||
-    action.id == "org.corectrl.helperkiller.init") &&
-    subject.local == true &&
-    subject.active == true &&
-    subject.isInGroup("users")) {
-    return polkit.Result.YES;
-    }
+    polkit.addRule(function (action, subject) {
+      if ((action.id == "org.corectrl.helper.init" ||
+          action.id == "org.corectrl.helperkiller.init") &&
+          subject.local == true &&
+          subject.active == true &&
+          subject.isInGroup("users")) {
+        return polkit.Result.YES;
+      }
     });
   '';
 


### PR DESCRIPTION
Following the advice of [this PR](https://github.com/NixOS/nixpkgs/pull/218437), we stop overriding the NixOS default.

To verify this actually works, `rebuild`, restart and run:

```bash
dmesg | grep modesetting
```

You should see `[drm] amdgpu kernel modesetting enabled`.

I also run prettier on the polkit function, if you don't want this change I can revert it.
