### PR TITLE
Enable SSD TRIM

### DIFF
--- a/hardware/default.nix
+++ b/hardware/default.nix
@@ -64,4 +64,6 @@ in
   fileSystems = lib.mkIf (config.boot.btrfs-compression.enable && config.boot.btrfs-compression.root.enable) {
     "/".options = [ "compress=zstd" ];
   };
+
+  services.fstrim.enable = true; # Enable SSD TRIM
 }


### PR DESCRIPTION
This is disabled by default for some reason and `nixos-hardware` enables it, so we probably should, too.