### PR TITLE
Remove xdg desktop portal from hyprland

### DIFF
--- a/system/desktop/hyprland/default.nix
+++ b/system/desktop/hyprland/default.nix
@@ -64,7 +64,5 @@
 
   security.polkit.enable = lib.mkIf config.desktop-environment.hyprland.enable true;
 
-  xdg.portal.extraPortals = [ pkgs.xdg-desktop-portal-gtk ]; # Needed for steam file picker
-
   disabledModules = [ "programs/hyprland.nix" ]; # Needed for hyprland flake
 }


### PR DESCRIPTION
As mentioned [here](https://github.com/NixOS/nixpkgs/issues/249645), this was made the default, so we no longer need to do it manually.