### PR TITLE
Add xpadneo unstable option

### DIFF
--- a/.nix
+++ b/.nix
@@ -329,5 +329,10 @@
       type = lib.types.bool;
       default = false;
     };
+
+    xpadneo-unstable.enable = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+    }; # use self-built version of xpadneo to fix some controller issues
   };
 }

--- a/hardware/default.nix
+++ b/hardware/default.nix
@@ -22,7 +22,8 @@ in {
       }; # Patch the driver for nvfbc
     };
 
-    xpadneo.enable = true; # Enable XBOX Gamepad bluetooth driver
+    xpadneo.enable =
+      !config.xpadneo-unstable.enable; # Enable XBOX Gamepad bluetooth driver
     bluetooth.enable = true;
     uinput.enable = true; # Enable uinput support
   };
@@ -52,14 +53,20 @@ in {
   boot = {
     kernelModules = [
       "v4l2loopback" # Virtual camera
-      "xpadneo"
       "uinput"
-    ];
+    ] ++ (if (config.xpadneo-unstable.enable) then
+      [ "hid_xpadneo" ]
+    else
+      [ "xpadneo" ]);
 
     kernelParams =
       [ "clearcpuid=514" ]; # Fixes certain wine games crash on launch
 
-    extraModulePackages = with config.boot.kernelPackages; [ v4l2loopback ];
+    extraModulePackages = with config.boot.kernelPackages;
+      [ v4l2loopback ] ++ (if (config.xpadneo-unstable.enable) then
+        [ (callPackage ../system/applications/self-built/xpadneo.nix { }) ]
+      else
+        [ ]);
 
     kernel.sysctl = {
       "vm.max_map_count" = 262144;

--- a/hardware/default.nix
+++ b/hardware/default.nix
@@ -54,10 +54,7 @@ in {
     kernelModules = [
       "v4l2loopback" # Virtual camera
       "uinput"
-    ] ++ (if (config.xpadneo-unstable.enable) then
-      [ "hid_xpadneo" ]
-    else
-      [ "xpadneo" ]);
+    ] ++ (if (config.xpadneo-unstable.enable) then [ "hid_xpadneo" ] else [ ]);
 
     kernelParams =
       [ "clearcpuid=514" ]; # Fixes certain wine games crash on launch

--- a/system/applications/self-built/xpadneo.nix
+++ b/system/applications/self-built/xpadneo.nix
@@ -1,0 +1,42 @@
+{ lib, stdenv, fetchFromGitHub, kernel, bluez, nixosTests }:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xpadneo";
+  version = "git";
+
+  src = fetchFromGitHub {
+    owner = "atar-axis";
+    repo = "xpadneo";
+    # rev = "refs/tags/v${finalAttrs.version}";
+    rev = "9b3b6968304d75faca00d1cead63f89e8895195f";
+    sha256 = "8XRyMXPqtQ413C2Rso2jA78Qv/UXWu2gmRgBHyAl6Rw=";
+  };
+
+  setSourceRoot = ''
+    export sourceRoot=$(pwd)/source/hid-xpadneo/src
+  '';
+
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+  buildInputs = [ bluez ];
+
+  makeFlags = kernel.makeFlags ++ [
+    "-C"
+    "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+    "M=$(sourceRoot)"
+    "VERSION=${finalAttrs.version}"
+  ];
+
+  buildFlags = [ "modules" ];
+  installFlags = [ "INSTALL_MOD_PATH=${placeholder "out"}" ];
+  installTargets = [ "modules_install" ];
+
+  passthru.tests = { xpadneo = nixosTests.xpadneo; };
+
+  meta = with lib; {
+    description = "Advanced Linux driver for Xbox One wireless controllers";
+    homepage = "https://atar-axis.github.io/xpadneo";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ kira-bruneau ];
+    platforms = platforms.linux;
+  };
+})


### PR DESCRIPTION
This PR adds an option to optionally use a newer, unreleased commit of xpadneo to allow support of GuliKit controllers, fixes for some controllers, etc. Off by default.