### PR TITLE
Replace deprecated argument of Firefox wrapper

### DIFF
--- a/system/applications/global.nix
+++ b/system/applications/global.nix
@@ -115,7 +115,7 @@ let
     [
       # Browser with pipewire-screenaudio connector json
       (firefox.override {
-        extraNativeMessagingHosts =
+        nativeMessagingHosts =
           [ inputs.pipewire-screenaudio.packages.${pkgs.system}.default ];
       })
     ];


### PR DESCRIPTION
trace: warning: The extraNativeMessagingHosts argument for the Firefox wrapper is deprecated, please use `nativeMessagingHosts`