### PR TITLE
Enable window snapping for gnome

### DIFF
--- a/system/desktop/gnome/home/main.nix
+++ b/system/desktop/gnome/home/main.nix
@@ -45,6 +45,8 @@ lib.mkIf config.system.user.main.enable {
         "org/gnome/desktop/sound" = { event-sounds = false; };
 
         "org/gnome/mutter" = {
+          # Enable window snapping to the edges of the screen
+          edge-tiling = true;
           # Enable fractional scaling
           experimental-features = [ "scale-monitor-framebuffer" ];
           dynamic-workspaces =

--- a/system/desktop/gnome/home/work.nix
+++ b/system/desktop/gnome/home/work.nix
@@ -51,6 +51,8 @@ lib.mkIf config.system.user.work.enable {
         "org/gnome/desktop/sound" = { event-sounds = false; };
 
         "org/gnome/mutter" = {
+          # Enable window snapping to the edges of the screen
+          edge-tiling = true;
           # Enable fractional scaling
           experimental-features = [ "scale-monitor-framebuffer" ];
           dynamic-workspaces =


### PR DESCRIPTION
Shouldn't affect you if you snap windows with the keyboard, so no reason to make this an option until someone asks.