### PR TITLE
Remove duplicate update script in main user apps

### DIFF
--- a/system/applications/main.nix
+++ b/system/applications/main.nix
@@ -37,7 +37,6 @@ in lib.mkIf config.system.user.main.enable {
       input-remapper # Remap input device controls
       scanmem # Cheat engine for linux
       stremio # Straming platform
-      update # Update the system configuration
     ] ++ emulators ++ gaming ++ myPackages ++ shellScripts;
 
   # Wayland microcompositor


### PR DESCRIPTION
It's already included in the shellScripts, so this is redundant.