### PR TITLE
Remove permitted insecure version of electron

### DIFF
--- a/system/applications/default.nix
+++ b/system/applications/default.nix
@@ -28,6 +28,5 @@
 
   nixpkgs.config = {
     allowUnfree = true; # Allow proprietary packages
-    permittedInsecurePackages = [ "electron-24.8.6" ];
   };
 }


### PR DESCRIPTION
This doesn't seem to be needed anymore, can you confirm?