### PR TITLE
Separate custom .nix config from nixos config

### DIFF
--- a/.nix
+++ b/.nix
@@ -2,678 +2,680 @@
 
 {
   options = with lib; {
-    applications = {
-      firefox = {
-        gnomeTheme = mkOption {
-          type = types.bool;
-          default = true;
-        };
-
-        privacy = mkOption {
-          type = types.bool;
-          default = true;
-        };
-
-        # Sites to launch on Firefox PWAs
-        pwas.sites = mkOption {
-          type = types.str;
-          default =
-            "https://app.tuta.com https://icedborn.github.io/icedchat https://discord.com/app https://dtekteam.slack.com/ https://web.skype.com/";
-        };
-      };
-
-      nvchad.formatOnSave = mkOption {
-        type = types.bool;
-        default = true;
-      };
-
-      # Hide kitty top bar
-      kitty.hideDecorations = mkOption {
-        type = types.bool;
-        default = true;
-      };
-
-      steam = {
-        adwaitaForSteam = {
-          enable = mkOption {
+    icedos = {
+      applications = {
+        firefox = {
+          gnomeTheme = mkOption {
             type = types.bool;
             default = true;
           };
 
-          # https://github.com/tkashkin/Adwaita-for-Steam/tree/master/adwaita/extras
-          extras = mkOption {
+          privacy = mkOption {
+            type = types.bool;
+            default = true;
+          };
+
+          # Sites to launch on Firefox PWAs
+          pwas.sites = mkOption {
             type = types.str;
             default =
-              "-e library/hide_whats_new -e login/hover_qr -e windowcontrols/hide-close";
+              "https://app.tuta.com https://icedborn.github.io/icedchat https://discord.com/app https://dtekteam.slack.com/ https://web.skype.com/";
           };
         };
 
-        beta = mkOption {
+        nvchad.formatOnSave = mkOption {
           type = types.bool;
           default = true;
         };
 
-        # Workaround for slow steam downloads
-        downloadsWorkaround = mkOption {
+        # Hide kitty top bar
+        kitty.hideDecorations = mkOption {
           type = types.bool;
           default = true;
         };
 
-        session = {
-          enable = mkOption {
+        steam = {
+          adwaitaForSteam = {
+            enable = mkOption {
+              type = types.bool;
+              default = true;
+            };
+
+            # https://github.com/tkashkin/Adwaita-for-Steam/tree/master/adwaita/extras
+            extras = mkOption {
+              type = types.str;
+              default =
+                "-e library/hide_whats_new -e login/hover_qr -e windowcontrols/hide-close";
+            };
+          };
+
+          beta = mkOption {
             type = types.bool;
-            default = false;
+            default = true;
           };
 
-          autoStart = {
+          # Workaround for slow steam downloads
+          downloadsWorkaround = mkOption {
+            type = types.bool;
+            default = true;
+          };
+
+          session = {
             enable = mkOption {
               type = types.bool;
               default = false;
             };
 
-            desktopSession = mkOption {
-              type = types.str;
-              default = "hyprland";
+            autoStart = {
+              enable = mkOption {
+                type = types.bool;
+                default = false;
+              };
+
+              desktopSession = mkOption {
+                type = types.str;
+                default = "hyprland";
+              };
+            };
+
+            decky = mkOption {
+              type = types.bool;
+              default = true;
+            };
+
+            steamdeck = mkOption {
+              type = types.bool;
+              default = false;
+            };
+          };
+        };
+      };
+
+      boot = {
+        # Hides startup text and displays a circular loading icon
+        animation = mkOption {
+          type = types.bool;
+          default = false;
+        };
+
+        grub = {
+          enable = mkOption {
+            type = types.bool;
+            default = false;
+          };
+
+          device = mkOption {
+            type = types.str;
+            default = "/dev/sda";
+          };
+        };
+
+        systemd-boot = {
+          enable = mkOption {
+            type = types.bool;
+            default = true;
+          };
+
+          mountPoint = mkOption {
+            type = types.str;
+            default = "/boot";
+          };
+        };
+
+        # Used for rebooting to windows with efibootmgr
+        windowsEntry = mkOption {
+          type = types.str;
+          default = "0000";
+        };
+      };
+
+      desktop = {
+        autologin = {
+          enable = mkOption {
+            type = types.bool;
+            default = true;
+          };
+
+          # If false, defaults to work user
+          main.user.enable = mkOption {
+            type = types.bool;
+            default = true;
+          };
+        };
+
+        gdm = {
+          enable = mkOption {
+            type = types.bool;
+            default = true;
+          };
+
+          autoSuspend = mkOption {
+            type = types.bool;
+            default = true;
+          };
+        };
+
+        gnome = {
+          enable = mkOption {
+            type = types.bool;
+            default = false;
+          };
+
+          extensions = {
+            arcmenu = mkOption {
+              type = types.bool;
+              default = false;
+            };
+
+            dashToPanel = mkOption {
+              type = types.bool;
+              default = false;
+            };
+
+            gsconnect = mkOption {
+              type = types.bool;
+              default = true;
+            };
+
+          };
+
+          # Show the month and day of the month on the clock
+          clock = {
+            date = mkOption {
+              type = types.bool;
+              default = false;
+            };
+
+            # Show the day of the week on the clock
+            weekday = mkOption {
+              type = types.bool;
+              default = false;
             };
           };
 
-          decky = mkOption {
+          hotCorners = mkOption {
+            type = types.bool;
+            default = false;
+          };
+
+          # Whether to set (or unset) gnome's and arcmenu's pinned apps
+          pinnedApps = mkOption {
+            type = types.bool;
+            default = false;
+          };
+
+          powerButtonAction = mkOption {
+            type = types.str;
+            default = "interactive";
+          };
+
+          startupItems = mkOption {
+            type = types.bool;
+            default = false;
+          };
+
+          # Options: 'minimize', 'maximize', 'close', 'spacer'(adds space between buttons), ':'(left-center-right separator)
+          titlebarLayout = mkOption {
+            type = types.str;
+            default = "appmenu:close";
+          };
+
+          workspaces = {
+            dynamicWorkspaces = mkOption {
+              type = types.bool;
+              default = true;
+            };
+
+            # Determines the maximum number of workspaces when dynamic workspaces are disabled
+            maxWorkspaces = mkOption {
+              type = types.str;
+              default = "1";
+            };
+          };
+        };
+
+        hyprland = {
+          enable = mkOption {
             type = types.bool;
             default = true;
           };
 
-          steamdeck = mkOption {
-            type = types.bool;
-            default = false;
+          lock = {
+            secondsToLowerBrightness = mkOption {
+              type = types.str;
+              default = "60";
+            };
+
+            # CPU usage to inhibit lock in percentage
+            cpuUsageThreshold = mkOption {
+              type = types.str;
+              default = "60";
+            };
+
+            # Disk usage to inhibit lock in MB/s
+            diskUsageThreshold = mkOption {
+              type = types.str;
+              default = "10";
+            };
+
+            # Network usage to inhibit lock in bytes/s
+            networkUsageThreshold = mkOption {
+              type = types.str;
+              default = "1000000";
+            };
           };
         };
       };
-    };
 
-    boot = {
-      # Hides startup text and displays a circular loading icon
-      animation = mkOption {
-        type = types.bool;
-        default = false;
-      };
-
-      grub = {
-        enable = mkOption {
-          type = types.bool;
-          default = false;
-        };
-
-        device = mkOption {
-          type = types.str;
-          default = "/dev/sda";
-        };
-      };
-
-      systemd-boot = {
-        enable = mkOption {
-          type = types.bool;
-          default = true;
-        };
-
-        mountPoint = mkOption {
-          type = types.str;
-          default = "/boot";
-        };
-      };
-
-      # Used for rebooting to windows with efibootmgr
-      windowsEntry = mkOption {
-        type = types.str;
-        default = "0000";
-      };
-    };
-
-    desktop = {
-      autologin = {
-        enable = mkOption {
-          type = types.bool;
-          default = true;
-        };
-
-        # If false, defaults to work user
-        main.user.enable = mkOption {
-          type = types.bool;
-          default = true;
-        };
-      };
-
-      gdm = {
-        enable = mkOption {
-          type = types.bool;
-          default = true;
-        };
-
-        autoSuspend = mkOption {
-          type = types.bool;
-          default = true;
-        };
-      };
-
-      gnome = {
-        enable = mkOption {
-          type = types.bool;
-          default = false;
-        };
-
-        extensions = {
-          arcmenu = mkOption {
-            type = types.bool;
-            default = false;
-          };
-
-          dashToPanel = mkOption {
-            type = types.bool;
-            default = false;
-          };
-
-          gsconnect = mkOption {
+      hardware = {
+        btrfsCompression = {
+          enable = mkOption {
             type = types.bool;
             default = true;
           };
 
-        };
-
-        # Show the month and day of the month on the clock
-        clock = {
-          date = mkOption {
-            type = types.bool;
-            default = false;
-          };
-
-          # Show the day of the week on the clock
-          weekday = mkOption {
-            type = types.bool;
-            default = false;
-          };
-        };
-
-        hotCorners = mkOption {
-          type = types.bool;
-          default = false;
-        };
-
-        # Whether to set (or unset) gnome's and arcmenu's pinned apps
-        pinnedApps = mkOption {
-          type = types.bool;
-          default = false;
-        };
-
-        powerButtonAction = mkOption {
-          type = types.str;
-          default = "interactive";
-        };
-
-        startupItems = mkOption {
-          type = types.bool;
-          default = false;
-        };
-
-        # Options: 'minimize', 'maximize', 'close', 'spacer'(adds space between buttons), ':'(left-center-right separator)
-        titlebarLayout = mkOption {
-          type = types.str;
-          default = "appmenu:close";
-        };
-
-        workspaces = {
-          dynamicWorkspaces = mkOption {
+          # Use btrfs compression for mounted drives
+          mounts = mkOption {
             type = types.bool;
             default = true;
           };
 
-          # Determines the maximum number of workspaces when dynamic workspaces are disabled
-          maxWorkspaces = mkOption {
-            type = types.str;
-            default = "1";
+          # Use btrfs compression for root
+          root = mkOption {
+            type = types.bool;
+            default = true;
           };
         };
-      };
 
-      hyprland = {
-        enable = mkOption {
-          type = types.bool;
-          default = true;
-        };
+        cpu = {
+          amd = {
+            enable = mkOption {
+              type = types.bool;
+              default = true;
+            };
 
-        lock = {
-          secondsToLowerBrightness = mkOption {
-            type = types.str;
-            default = "60";
+            undervolt = {
+              enable = mkOption {
+                type = types.bool;
+                default = true;
+              };
+
+              value = mkOption {
+                type = types.str;
+                # Pstate 0, 1.175 voltage, 4000 clock speed
+                default = "-p 0 -v 3C -f A0";
+              };
+            };
           };
 
-          # CPU usage to inhibit lock in percentage
-          cpuUsageThreshold = mkOption {
-            type = types.str;
-            default = "60";
-          };
-
-          # Disk usage to inhibit lock in MB/s
-          diskUsageThreshold = mkOption {
-            type = types.str;
-            default = "10";
-          };
-
-          # Network usage to inhibit lock in bytes/s
-          networkUsageThreshold = mkOption {
-            type = types.str;
-            default = "1000000";
+          intel.enable = mkOption {
+            type = types.bool;
+            default = false;
           };
         };
-      };
-    };
 
-    hardware = {
-      btrfsCompression = {
-        enable = mkOption {
-          type = types.bool;
-          default = true;
+        gpu = {
+          amd = mkOption {
+            type = types.bool;
+            default = true;
+          };
+
+          nvidia = {
+            enable = mkOption {
+              type = types.bool;
+              default = false;
+            };
+
+            powerLimit = {
+              enable = mkOption {
+                type = types.bool;
+                default = true;
+              };
+
+              # RTX 3070
+              value = mkOption {
+                type = types.str;
+                default = "242";
+              };
+            };
+          };
         };
 
-        # Use btrfs compression for mounted drives
+        laptop = {
+          enable = mkOption {
+            type = types.bool;
+            default = false;
+          };
+
+          autoCpuFreq = mkOption {
+            type = types.bool;
+            default = true;
+          };
+        };
+
+        monitors = {
+          main = {
+            enable = mkOption {
+              type = types.bool;
+              default = true;
+            };
+
+            name = mkOption {
+              type = types.str;
+              default = "DP-1";
+            };
+
+            resolution = mkOption {
+              type = types.str;
+              default = "1920x1080";
+            };
+
+            refreshRate = mkOption {
+              type = types.str;
+              default = "144";
+            };
+
+            position = mkOption {
+              type = types.str;
+              default = "0x0";
+            };
+
+            scaling = mkOption {
+              type = types.str;
+              default = "1";
+            };
+
+            rotation = mkOption {
+              type = types.str;
+              default = "0";
+            };
+          };
+
+          secondary = {
+            enable = mkOption {
+              type = types.bool;
+              default = true;
+            };
+
+            name = mkOption {
+              type = types.str;
+              default = "DP-2";
+            };
+
+            resolution = mkOption {
+              type = types.str;
+              default = "1360x768";
+            };
+
+            refreshRate = mkOption {
+              type = types.str;
+              default = "60";
+            };
+
+            position = mkOption {
+              type = types.str;
+              default = "1920x0";
+            };
+
+            scaling = mkOption {
+              type = types.str;
+              default = "0.8";
+            };
+
+            rotation = mkOption {
+              type = types.str;
+              default = "0";
+            };
+          };
+        };
+
+        networking = {
+          hostname = mkOption {
+            type = types.str;
+            default = "desktop";
+          };
+
+          hosts.enable = mkOption {
+            type = types.bool;
+            default = false;
+          };
+
+          ipv6 = mkOption {
+            type = types.bool;
+            default = false;
+          };
+        };
+
+        # Set to false if hardware/mounts.nix is not correctly configured
         mounts = mkOption {
           type = types.bool;
           default = true;
         };
 
-        # Use btrfs compression for root
-        root = mkOption {
+        virtualisation = {
+          # Container manager
+          docker = mkOption {
+            type = types.bool;
+            default = true;
+          };
+
+          # A daemon that manages virtual machines
+          libvirtd = mkOption {
+            type = types.bool;
+            default = true;
+          };
+
+          # Container daemon
+          lxd = mkOption {
+            type = types.bool;
+            default = true;
+          };
+
+          # Passthrough USB devices to vms
+          spiceUSBRedirection = mkOption {
+            type = types.bool;
+            default = true;
+          };
+
+          # Android container
+          waydroid = mkOption {
+            type = types.bool;
+            default = true;
+          };
+        };
+
+        # use self-built version of xpadneo to fix some controller issues
+        xpadneoUnstable = mkOption {
           type = types.bool;
           default = true;
         };
       };
 
-      cpu = {
-        amd = {
-          enable = mkOption {
-            type = types.bool;
-            default = true;
+      system = {
+        config.version = mkOption {
+          type = types.str;
+          default = "1.0.0";
+        };
+
+        gc = {
+          # Number of days before a generation can be deleted
+          days = mkOption {
+            type = types.str;
+            default = "0";
           };
 
-          undervolt = {
+          # Number of generations that will always be kept
+          generations = mkOption {
+            type = types.str;
+            default = "10";
+          };
+        };
+
+        home = mkOption {
+          type = types.str;
+          default = "/home";
+        };
+
+        swappiness = mkOption {
+          type = types.str;
+          default = "1";
+        };
+
+        update.stash = mkOption {
+          type = types.str;
+          default = "true";
+        };
+
+        user = {
+          main = {
             enable = mkOption {
               type = types.bool;
               default = true;
             };
 
-            value = mkOption {
+            username = mkOption {
               type = types.str;
-              # Pstate 0, 1.175 voltage, 4000 clock speed
-              default = "-p 0 -v 3C -f A0";
+              default = "icedborn";
+            };
+
+            description = mkOption {
+              type = types.str;
+              default = "IceDBorn";
+            };
+
+            git = {
+              username = mkOption {
+                type = types.str;
+                default = "IceDBorn";
+              };
+
+              email = mkOption {
+                type = types.str;
+                default = "git.outsider841@simplelogin.fr";
+              };
+            };
+
+            desktop = {
+              idle = {
+                lock = {
+                  enable = mkOption {
+                    type = types.bool;
+                    default = true;
+                  };
+
+                  seconds = mkOption {
+                    type = types.str;
+                    default = "180";
+                  };
+                };
+
+                disableMonitors = {
+                  enable = mkOption {
+                    type = types.bool;
+                    default = true;
+                  };
+
+                  seconds = mkOption {
+                    type = types.str;
+                    default = "300";
+                  };
+                };
+
+                suspend = {
+                  enable = mkOption {
+                    type = types.bool;
+                    default = true;
+                  };
+
+                  seconds = mkOption {
+                    type = types.str;
+                    default = "900";
+                  };
+                };
+              };
             };
           };
-        };
 
-        intel.enable = mkOption {
-          type = types.bool;
-          default = false;
-        };
-      };
-
-      gpu = {
-        amd = mkOption {
-          type = types.bool;
-          default = true;
-        };
-
-        nvidia = {
-          enable = mkOption {
-            type = types.bool;
-            default = false;
-          };
-
-          powerLimit = {
+          work = {
             enable = mkOption {
+              type = types.bool;
+              default = false;
+            };
+
+            username = mkOption {
+              type = types.str;
+              default = "work";
+            };
+
+            description = mkOption {
+              type = types.str;
+              default = "Work";
+            };
+
+            git = {
+              username = mkOption {
+                type = types.str;
+                default = "IceDBorn";
+              };
+
+              email = mkOption {
+                type = types.str;
+                default = "git.outsider841@simplelogin.fr";
+              };
+            };
+
+            httpd = mkOption {
               type = types.bool;
               default = true;
             };
 
-            # RTX 3070
-            value = mkOption {
-              type = types.str;
-              default = "242";
+            desktop = {
+              idle = {
+                lock = {
+                  enable = mkOption {
+                    type = types.bool;
+                    default = true;
+                  };
+
+                  seconds = mkOption {
+                    type = types.str;
+                    default = "180";
+                  };
+                };
+
+                disableMonitors = {
+                  enable = mkOption {
+                    type = types.bool;
+                    default = true;
+                  };
+
+                  seconds = mkOption {
+                    type = types.str;
+                    default = "300";
+                  };
+                };
+
+                suspend = {
+                  enable = mkOption {
+                    type = types.bool;
+                    default = true;
+                  };
+
+                  seconds = mkOption {
+                    type = types.str;
+                    default = "900";
+                  };
+                };
+              };
             };
           };
         };
-      };
 
-      laptop = {
-        enable = mkOption {
-          type = types.bool;
-          default = false;
-        };
-
-        autoCpuFreq = mkOption {
-          type = types.bool;
-          default = true;
-        };
-      };
-
-      monitors = {
-        main = {
-          enable = mkOption {
-            type = types.bool;
-            default = true;
-          };
-
-          name = mkOption {
-            type = types.str;
-            default = "DP-1";
-          };
-
-          resolution = mkOption {
-            type = types.str;
-            default = "1920x1080";
-          };
-
-          refreshRate = mkOption {
-            type = types.str;
-            default = "144";
-          };
-
-          position = mkOption {
-            type = types.str;
-            default = "0x0";
-          };
-
-          scaling = mkOption {
-            type = types.str;
-            default = "1";
-          };
-
-          rotation = mkOption {
-            type = types.str;
-            default = "0";
-          };
-        };
-
-        secondary = {
-          enable = mkOption {
-            type = types.bool;
-            default = true;
-          };
-
-          name = mkOption {
-            type = types.str;
-            default = "DP-2";
-          };
-
-          resolution = mkOption {
-            type = types.str;
-            default = "1360x768";
-          };
-
-          refreshRate = mkOption {
-            type = types.str;
-            default = "60";
-          };
-
-          position = mkOption {
-            type = types.str;
-            default = "1920x0";
-          };
-
-          scaling = mkOption {
-            type = types.str;
-            default = "0.8";
-          };
-
-          rotation = mkOption {
-            type = types.str;
-            default = "0";
-          };
-        };
-      };
-
-      networking = {
-        hostname = mkOption {
+        # Do not change without checking the docs (config.system.stateVersion)
+        version = mkOption {
           type = types.str;
-          default = "desktop";
+          default = "23.05";
         };
-
-        hosts.enable = mkOption {
-          type = types.bool;
-          default = false;
-        };
-
-        ipv6 = mkOption {
-          type = types.bool;
-          default = false;
-        };
-      };
-
-      # Set to false if hardware/mounts.nix is not correctly configured
-      mounts = mkOption {
-        type = types.bool;
-        default = true;
-      };
-
-      virtualisation = {
-        # Container manager
-        docker = mkOption {
-          type = types.bool;
-          default = true;
-        };
-
-        # A daemon that manages virtual machines
-        libvirtd = mkOption {
-          type = types.bool;
-          default = true;
-        };
-
-        # Container daemon
-        lxd = mkOption {
-          type = types.bool;
-          default = true;
-        };
-
-        # Passthrough USB devices to vms
-        spiceUSBRedirection = mkOption {
-          type = types.bool;
-          default = true;
-        };
-
-        # Android container
-        waydroid = mkOption {
-          type = types.bool;
-          default = true;
-        };
-      };
-
-      # use self-built version of xpadneo to fix some controller issues
-      xpadneoUnstable = mkOption {
-        type = types.bool;
-        default = true;
-      };
-    };
-
-    system = {
-      config.version = mkOption {
-        type = types.str;
-        default = "1.0.0";
-      };
-
-      gc = {
-        # Number of days before a generation can be deleted
-        days = mkOption {
-          type = types.str;
-          default = "0";
-        };
-
-        # Number of generations that will always be kept
-        generations = mkOption {
-          type = types.str;
-          default = "10";
-        };
-      };
-
-      home = mkOption {
-        type = types.str;
-        default = "/home";
-      };
-
-      swappiness = mkOption {
-        type = types.str;
-        default = "1";
-      };
-
-      update.stash = mkOption {
-        type = types.str;
-        default = "true";
-      };
-
-      user = {
-        main = {
-          enable = mkOption {
-            type = types.bool;
-            default = true;
-          };
-
-          username = mkOption {
-            type = types.str;
-            default = "icedborn";
-          };
-
-          description = mkOption {
-            type = types.str;
-            default = "IceDBorn";
-          };
-
-          git = {
-            username = mkOption {
-              type = types.str;
-              default = "IceDBorn";
-            };
-
-            email = mkOption {
-              type = types.str;
-              default = "git.outsider841@simplelogin.fr";
-            };
-          };
-
-          desktop = {
-            idle = {
-              lock = {
-                enable = mkOption {
-                  type = types.bool;
-                  default = true;
-                };
-
-                seconds = mkOption {
-                  type = types.str;
-                  default = "180";
-                };
-              };
-
-              disableMonitors = {
-                enable = mkOption {
-                  type = types.bool;
-                  default = true;
-                };
-
-                seconds = mkOption {
-                  type = types.str;
-                  default = "300";
-                };
-              };
-
-              suspend = {
-                enable = mkOption {
-                  type = types.bool;
-                  default = true;
-                };
-
-                seconds = mkOption {
-                  type = types.str;
-                  default = "900";
-                };
-              };
-            };
-          };
-        };
-
-        work = {
-          enable = mkOption {
-            type = types.bool;
-            default = false;
-          };
-
-          username = mkOption {
-            type = types.str;
-            default = "work";
-          };
-
-          description = mkOption {
-            type = types.str;
-            default = "Work";
-          };
-
-          git = {
-            username = mkOption {
-              type = types.str;
-              default = "IceDBorn";
-            };
-
-            email = mkOption {
-              type = types.str;
-              default = "git.outsider841@simplelogin.fr";
-            };
-          };
-
-          httpd = mkOption {
-            type = types.bool;
-            default = true;
-          };
-
-          desktop = {
-            idle = {
-              lock = {
-                enable = mkOption {
-                  type = types.bool;
-                  default = true;
-                };
-
-                seconds = mkOption {
-                  type = types.str;
-                  default = "180";
-                };
-              };
-
-              disableMonitors = {
-                enable = mkOption {
-                  type = types.bool;
-                  default = true;
-                };
-
-                seconds = mkOption {
-                  type = types.str;
-                  default = "300";
-                };
-              };
-
-              suspend = {
-                enable = mkOption {
-                  type = types.bool;
-                  default = true;
-                };
-
-                seconds = mkOption {
-                  type = types.str;
-                  default = "900";
-                };
-              };
-            };
-          };
-        };
-      };
-
-      # Do not change without checking the docs (config.system.stateVersion)
-      version = mkOption {
-        type = types.str;
-        default = "23.05";
       };
     };
   };

--- a/hardware/amd/radeon.nix
+++ b/hardware/amd/radeon.nix
@@ -1,7 +1,10 @@
 { pkgs, lib, config, ... }:
 
-let cfg = config.hardware.gpu.amd;
-in lib.mkIf cfg {
+let
+  inherit (lib) mkIf;
+
+  cfg = config.icedos.hardware.gpu.amd;
+in mkIf (cfg) {
   boot = {
     initrd.kernelModules = [ "amdgpu" ]; # Use the amdgpu drivers upon boot
     kernelParams =

--- a/hardware/amd/ryzen.nix
+++ b/hardware/amd/ryzen.nix
@@ -1,18 +1,19 @@
 { pkgs, lib, config, ... }:
 
 let
-  cfg = config.hardware.cpu.amd;
-  kernelPackages = config.boot.kernelPackages;
-in lib.mkIf cfg.enable {
+  inherit (lib) mkIf;
+
+  cfg = config.icedos.hardware.cpu.amd;
+in mkIf (cfg.enable) {
   boot = {
     kernelModules = [ "msr" "zenpower" ];
-    extraModulePackages = with kernelPackages; [ zenpower ];
+    extraModulePackages = with config.boot.kernelPackages; [ zenpower ];
   };
 
   hardware.cpu.amd.updateMicrocode = true;
 
   # Ryzen cpu control
-  systemd.services.zenstates = lib.mkIf cfg.undervolt.enable {
+  systemd.services.zenstates = mkIf (cfg.undervolt.enable) {
     enable = true;
     description = "Ryzen Undervolt";
     after = [ "syslog.target" "systemd-modules-load.service" ];

--- a/hardware/bootloader.nix
+++ b/hardware/bootloader.nix
@@ -1,15 +1,18 @@
 { config, lib, ... }:
 
-let cfg = config.boot;
+let
+  inherit (lib) mkIf;
+
+  cfg = config.icedos.boot;
 in {
   boot = {
     loader = {
-      efi = lib.mkIf cfg.systemd-boot.enable {
+      efi = mkIf (cfg.systemd-boot.enable) {
         canTouchEfiVariables = true;
         efiSysMountPoint = cfg.systemd-boot.mountPoint;
       };
 
-      grub = lib.mkIf cfg.grub.enable {
+      grub = mkIf (cfg.grub.enable) {
         enable = true;
         device = cfg.grub.device;
         useOSProber = true;
@@ -17,7 +20,7 @@ in {
         configurationLimit = 10;
       };
 
-      systemd-boot = lib.mkIf cfg.systemd-boot.enable {
+      systemd-boot = mkIf (cfg.systemd-boot.enable) {
         enable = true;
         configurationLimit = 10;
         # Select the highest resolution for the bootloader
@@ -28,7 +31,7 @@ in {
       timeout = 1;
     };
 
-    initrd.secrets = lib.mkIf cfg.grub.enable { "/crypto_keyfile.bin" = null; };
+    initrd.secrets = mkIf (cfg.grub.enable) { "/crypto_keyfile.bin" = null; };
 
     plymouth.enable = cfg.animation;
   };

--- a/hardware/deckbd-wrapper.nix
+++ b/hardware/deckbd-wrapper.nix
@@ -1,9 +1,12 @@
 { pkgs, lib, config, ... }:
 
 let
+  inherit (lib) mkIf;
+
+  cfg = config.icedos.applications.steam.session;
+
   deckbd = "${pkgs.deckbd}/bin/deckbd";
-  cfg = config.applications.steam.session;
-in lib.mkIf (cfg.enable && cfg.steamdeck) {
+in mkIf (cfg.enable && cfg.steamdeck) {
   boot.initrd = {
     preLVMCommands = ''
       DECKBD_RETRIES=10

--- a/hardware/intel.nix
+++ b/hardware/intel.nix
@@ -1,6 +1,7 @@
 { config, ... }:
 
-{
-  hardware.cpu.intel.updateMicrocode = config.hardware.cpu.intel.enable;
-  services.throttled.enable = config.hardware.cpu.intel.enable;
+let cfg = config.icedos.hardware.cpu.intel.enable;
+in {
+  hardware.cpu.intel.updateMicrocode = cfg;
+  services.throttled.enable = cfg;
 }

--- a/hardware/laptop.nix
+++ b/hardware/laptop.nix
@@ -1,10 +1,14 @@
 { pkgs, lib, config, ... }:
 
-lib.mkIf config.hardware.laptop.enable {
-  services.auto-cpufreq.enable = config.hardware.laptop.autoCpuFreq;
+let
+  inherit (lib) mkIf;
+
+  cfg = config.icedos.hardware;
+in mkIf (cfg.laptop.enable) {
+  services.auto-cpufreq.enable = cfg.laptop.autoCpuFreq;
   environment.systemPackages = [ pkgs.brightnessctl ];
 
-  hardware.nvidia.prime = lib.mkIf config.hardware.gpu.nvidia.enable {
+  hardware.nvidia.prime = mkIf (cfg.gpu.nvidia.enable) {
     offload.enable = true;
     intelBusId = "PCI:0:2:0";
     nvidiaBusId = "PCI:1:0:0";

--- a/hardware/mounts.nix
+++ b/hardware/mounts.nix
@@ -1,24 +1,29 @@
 { lib, config, ... }:
 
-lib.mkIf config.hardware.mounts {
+let
+  inherit (lib) mkIf;
+
+  cfg = config.icedos.hardware;
+  btrfsCompression = cfg.btrfsCompression;
+in mkIf (cfg.mounts) {
   fileSystems."/mnt/games" = {
     device = "/dev/disk/by-uuid/89afb683-90b4-4291-82af-5d3238c8bd3d";
     fsType = "btrfs";
-    options = lib.mkIf (config.hardware.btrfsCompression.enable
-      && config.hardware.btrfsCompression.mounts) [ "compress=zstd" ];
+    options = mkIf (btrfsCompression.enable && btrfsCompression.mounts)
+      [ "compress=zstd" ];
   };
 
   fileSystems."/mnt/storage" = {
     device = "/dev/disk/by-uuid/4b2d6cf0-f73a-4b4a-820a-db5b5aa17efa";
     fsType = "btrfs";
-    options = lib.mkIf (config.hardware.btrfsCompression.enable
-      && config.hardware.btrfsCompression.mounts) [ "compress=zstd" ];
+    options = mkIf (btrfsCompression.enable && btrfsCompression.mounts)
+      [ "compress=zstd" ];
   };
 
   fileSystems."/mnt/ssdgames" = {
     device = "/dev/disk/by-uuid/040329ae-685d-4ba6-8bdd-e0a9785f9672";
     fsType = "btrfs";
-    options = lib.mkIf (config.hardware.btrfsCompression.enable
-      && config.hardware.btrfsCompression.mounts) [ "compress=zstd" ];
+    options = mkIf (btrfsCompression.enable && btrfsCompression.mounts)
+      [ "compress=zstd" ];
   };
 }

--- a/hardware/nvidia.nix
+++ b/hardware/nvidia.nix
@@ -1,5 +1,11 @@
 { config, pkgs, lib, ... }:
 let
+  inherit (lib) mkIf optional;
+
+  cfg = config.icedos;
+  powerLimit = cfg.hardware.gpu.nvidia.powerLimit;
+  nvidia_x11 = cfg.boot.kernelPackages.nvidia_x11.bin;
+
   nvidia-offload = pkgs.writeShellScriptBin "nvidia-offload" ''
     export __NV_PRIME_RENDER_OFFLOAD=1
     export __NV_PRIME_RENDER_OFFLOAD_PROVIDER=NVIDIA-G0
@@ -7,37 +13,33 @@ let
     export __VK_LAYER_NV_optimus=NVIDIA_only
     exec "$@"
   '';
-in lib.mkIf config.hardware.gpu.nvidia.enable {
+in mkIf (cfg.hardware.gpu.nvidia.enable) {
   services.xserver.videoDrivers = [ "nvidia" ]; # Install the nvidia drivers
 
   hardware.nvidia.modesetting.enable = true; # Required for wayland
 
   virtualisation.docker.enableNvidia =
-    config.hardware.virtualisation.docker; # Enable nvidia gpu acceleration for docker
+    cfg.hardware.virtualisation.docker; # Enable nvidia gpu acceleration for docker
 
   environment.systemPackages =
     [ pkgs.nvtop-nvidia ] # Monitoring tool for nvidia GPUs
-    ++ lib.optional config.hardware.laptop.enable
+    ++ optional (cfg.hardware.laptop.enable)
     nvidia-offload; # Use nvidia-offload to launch programs using the nvidia GPU
 
   # Set nvidia gpu power limit
-  systemd.services.nv-power-limit =
-    lib.mkIf config.hardware.gpu.nvidia.powerLimit.enable {
-      enable = true;
-      description = "Nvidia power limit control";
-      after = [ "syslog.target" "systemd-modules-load.service" ];
+  systemd.services.nv-power-limit = mkIf (powerLimit.enable) {
+    enable = true;
+    description = "Nvidia power limit control";
+    after = [ "syslog.target" "systemd-modules-load.service" ];
 
-      unitConfig = {
-        ConditionPathExists =
-          "${config.boot.kernelPackages.nvidia_x11.bin}/bin/nvidia-smi";
-      };
+    unitConfig = { ConditionPathExists = "${nvidia_x11}/bin/nvidia-smi"; };
 
-      serviceConfig = {
-        User = "root";
-        ExecStart =
-          "${config.boot.kernelPackages.nvidia_x11.bin}/bin/nvidia-smi  --power-limit=${config.hardware.gpu.nvidia.powerLimit.value}";
-      };
-
-      wantedBy = [ "multi-user.target" ];
+    serviceConfig = {
+      User = "root";
+      ExecStart =
+        "${nvidia_x11}/bin/nvidia-smi --power-limit=${powerLimit.value}";
     };
+
+    wantedBy = [ "multi-user.target" ];
+  };
 }

--- a/hardware/virtualisation.nix
+++ b/hardware/virtualisation.nix
@@ -1,20 +1,23 @@
 { pkgs, config, lib, ... }:
 
-{
+let
+  inherit (lib) mkIf;
+
+  cfg = config.icedos.hardware.virtualisation;
+in {
   virtualisation = {
-    docker.enable = config.hardware.virtualisation.docker;
-    libvirtd.enable = config.hardware.virtualisation.libvirtd;
-    lxd.enable = config.hardware.virtualisation.lxd;
-    spiceUSBRedirection.enable =
-      config.hardware.virtualisation.spiceUSBRedirection;
-    waydroid.enable = config.hardware.virtualisation.waydroid;
+    docker.enable = cfg.docker;
+    libvirtd.enable = cfg.libvirtd;
+    lxd.enable = cfg.lxd;
+    spiceUSBRedirection.enable = cfg.spiceUSBRedirection;
+    waydroid.enable = cfg.waydroid;
   };
 
   environment.systemPackages = with pkgs;
-    lib.mkIf (config.hardware.virtualisation.docker) [
+    mkIf (cfg.docker) [
       docker # Containers
       distrobox # Wrapper around docker to create and start linux containers
     ];
 
-  programs.virt-manager.enable = config.hardware.virtualisation.libvirtd;
+  programs.virt-manager.enable = cfg.libvirtd;
 }

--- a/modules.nix
+++ b/modules.nix
@@ -1,6 +1,7 @@
 { config, ... }:
 
-{
+let cfg = config.icedos.system;
+in {
   imports = [
     # Auto-generated configuration by NixOS
     ./hardware/nixos/hardware-configuration.nix
@@ -26,5 +27,5 @@
     ./system/users.nix
   ];
 
-  config.system.stateVersion = config.system.version;
+  config.system.stateVersion = cfg.version;
 }

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -8,4 +8,4 @@ CONFIG="/tmp/configuration-location"
 printf "$PWD" > "$CONFIG"
 
 # Build the system configuration
-nixos-rebuild switch --impure --flake .#"$(cat /etc/hostname)"
+nixos-rebuild switch --show-trace --impure --flake .#"$(cat /etc/hostname)"

--- a/system/applications/configs/nvchad/init.nix
+++ b/system/applications/configs/nvchad/init.nix
@@ -1,9 +1,13 @@
 { config, lib, ... }:
 let
-  mapAttrsAndKeys = callback: list:
-    (lib.foldl' (acc: value: acc // (callback value)) { } list);
+  inherit (lib) attrNames filter foldl';
 
-  formatOnSave = if (config.applications.nvchad.formatOnSave) then ''
+  cfg = config.icedos;
+
+  mapAttrsAndKeys = callback: list:
+    (foldl' (acc: value: acc // (callback value)) { } list);
+
+  formatOnSave = if (cfg.applications.nvchad.formatOnSave) then ''
     -- Format on sav
     vim.cmd [[
         augroup format_on_save
@@ -15,10 +19,10 @@ let
     "";
 in {
   home-manager.users = let
-    users = lib.filter (user: config.system.user.${user}.enable == true)
-      (lib.attrNames config.system.user);
+    users =
+      filter (user: cfg.system.user.${user}.enable == true) (attrNames cfg);
   in mapAttrsAndKeys (user:
-    let username = config.system.user.${user}.username;
+    let username = cfg.system.user.${user}.username;
     in {
       ${username}.home.file.".config/nvim/lua/custom/init.lua".text = ''
           -- Enable blinking

--- a/system/applications/configs/pipewire.nix
+++ b/system/applications/configs/pipewire.nix
@@ -1,52 +1,55 @@
 { lib, config, pkgs, ... }:
 
 let
-  mapAttrsAndKeys = callback: list:
-    (lib.foldl' (acc: value: acc // (callback value)) { } list);
-in {
-  home-manager.users = let
-    users = lib.filter (user: config.system.user.${user}.enable == true)
-      (lib.attrNames config.system.user);
-  in mapAttrsAndKeys (user:
-    let username = config.system.user.${user}.username;
+  inherit (lib) attrNames filter foldl';
 
-    in {
-      ${username}.home.file.".config/pipewire/pipewire.conf.d/99-input-denoising.conf".text =
-        ''
-          context.modules = [
-            {
-              name = libpipewire-module-filter-chain
-              args = {
-                node.description =  "Noise Canceling source"
-                media.name =  "Noise Canceling source"
-                filter.graph = {
-                  nodes = [
-                    {
-                      type = ladspa
-                      name = rnnoise
-                      plugin = ${pkgs.rnnoise-plugin}/lib/ladspa/librnnoise_ladspa.so
-                      label = noise_suppressor_mono
-                      control = {
-                        "VAD Threshold (%)" 95.0
-                        "VAD Grace Period (ms)" 200
-                        "Retroactive VAD Grace (ms)" 0
+  cfg = config.icedos.system.user;
+
+  mapAttrsAndKeys = callback: list:
+    (foldl' (acc: value: acc // (callback value)) { } list);
+in {
+  home-manager.users =
+    let users = filter (user: cfg.${user}.enable == true) (attrNames cfg);
+    in mapAttrsAndKeys (user:
+      let username = cfg.${user}.username;
+
+      in {
+        ${username}.home.file.".config/pipewire/pipewire.conf.d/99-input-denoising.conf".text =
+          ''
+            context.modules = [
+              {
+                name = libpipewire-module-filter-chain
+                args = {
+                  node.description =  "Noise Canceling source"
+                  media.name =  "Noise Canceling source"
+                  filter.graph = {
+                    nodes = [
+                      {
+                        type = ladspa
+                        name = rnnoise
+                        plugin = ${pkgs.rnnoise-plugin}/lib/ladspa/librnnoise_ladspa.so
+                        label = noise_suppressor_mono
+                        control = {
+                          "VAD Threshold (%)" 95.0
+                          "VAD Grace Period (ms)" 200
+                          "Retroactive VAD Grace (ms)" 0
+                        }
                       }
-                    }
-                  ]
-                }
-                capture.props = {
-                  node.name =  "capture.rnnoise_source"
-                  node.passive = true
-                  audio.rate = 48000
-                }
-                playback.props = {
-                  node.name =  "rnnoise_source"
-                  media.class = Audio/Source
-                  audio.rate = 48000
+                    ]
+                  }
+                  capture.props = {
+                    node.name =  "capture.rnnoise_source"
+                    node.passive = true
+                    audio.rate = 48000
+                  }
+                  playback.props = {
+                    node.name =  "rnnoise_source"
+                    media.class = Audio/Source
+                    audio.rate = 48000
+                  }
                 }
               }
-            }
-          ]
-        '';
-    }) users;
+            ]
+          '';
+      }) users;
 }

--- a/system/applications/default.nix
+++ b/system/applications/default.nix
@@ -1,6 +1,7 @@
 { config, inputs, ... }:
 
-{
+let cfg = config.icedos.system.config;
+in {
   imports = [
     ./global.nix # Packages installed globally
     ./main.nix # Packages installed for main user
@@ -38,5 +39,5 @@
   };
 
   # Versioning system
-  environment.etc."icedos-version".text = config.system.config.version;
+  environment.etc."icedos-version".text = cfg.version;
 }

--- a/system/applications/global.nix
+++ b/system/applications/global.nix
@@ -2,6 +2,10 @@
 { pkgs, config, inputs, lib, ... }:
 
 let
+  inherit (lib) mkIf;
+
+  cfg = config.icedos;
+
   # Logout from any shell
   lout = pkgs.writeShellScriptBin "lout" ''
     pkill -KILL -u $USER
@@ -9,12 +13,12 @@ let
 
   # Garbage collect the nix store
   nix-gc = pkgs.writeShellScriptBin "nix-gc" ''
-    gens=${config.system.gc.generations} ;
-    days=${config.system.gc.days} ;
+    gens=${cfg.system.gc.generations} ;
+    days=${cfg.system.gc.days} ;
     trim-generations ''${1:-$gens} ''${2:-$days} user ;
     trim-generations ''${1:-$gens} ''${2:-$days} home-manager ;
-    sudo -H -u ${config.system.user.work.username} env Gens="''${1:-$gens}" Days="''${2:-$days}" bash -c 'trim-generations $Gens $Days user' ;
-    sudo -H -u ${config.system.user.work.username} env Gens="''${1:-$gens}" Days="''${2:-$days}" bash -c 'trim-generations $Gens $Days home-manager' ;
+    sudo -H -u ${cfg.system.user.work.username} env Gens="''${1:-$gens}" Days="''${2:-$days}" bash -c 'trim-generations $Gens $Days user' ;
+    sudo -H -u ${cfg.system.user.work.username} env Gens="''${1:-$gens}" Days="''${2:-$days}" bash -c 'trim-generations $Gens $Days home-manager' ;
     sudo trim-generations ''${1:-$gens} ''${2:-$days} system ;
     nix-store --gc
   '';
@@ -104,7 +108,7 @@ let
 in {
   imports = [ configs/pipewire.nix ];
 
-  boot.kernelPackages = lib.mkIf (!config.applications.steam.session.steamdeck
+  boot.kernelPackages = mkIf (!cfg.applications.steam.session.steamdeck
     && builtins.pathExists /etc/icedos-version)
     pkgs.linuxPackages_cachyos; # Use CachyOS optimized linux kernel
 
@@ -204,7 +208,7 @@ in {
         r-store =
           "nix-store --verify --check-contents --repair"; # Verifies integrity and repairs inconsistencies between Nix database and store
         r-windows =
-          "sudo efibootmgr --bootnext ${config.boot.windowsEntry} && reboot"; # Reboot to windows
+          "sudo efibootmgr --bootnext ${cfg.boot.windowsEntry} && reboot"; # Reboot to windows
         ssh = "TERM=xterm-256color ssh"; # SSH with colors
         v = "nvim"; # Neovim
       };

--- a/system/applications/work.nix
+++ b/system/applications/work.nix
@@ -4,10 +4,10 @@
 let
   inherit (lib) mkIf optional;
 
-  cfg = config.icedos;
-  username = cfg.system.user.work.username;
+  cfg = config.icedos.system;
+  username = cfg.user.work.username;
 
-  stashLock = if (cfg.system.update.stashFlakeLock) then "1" else "0";
+  stashLock = if (cfg.update.stashFlakeLock) then "1" else "0";
 
   sail = import modules/run-command.nix {
     inherit pkgs;
@@ -20,7 +20,7 @@ let
     inherit pkgs config;
     command = "update";
     update = "true";
-    stash = cfg.system.update.stash;
+    stash = cfg.update.stash;
   };
 
   # Packages to add for a fork of the config
@@ -28,7 +28,7 @@ let
 
   shellScripts = [ sail update ];
 
-  gitLocation = "${cfg.system.home}/${username}/git/";
+  gitLocation = "${cfg.home}/${username}/git/";
 
   multiStoreProjects = {
     vaza = {
@@ -57,7 +57,7 @@ let
     Alias /${multiStoreProjects.tosupermou.alias} ${gitLocation}${multiStoreProjects.tosupermou.folder}
     Alias /${multiStoreProjects.papiros.alias} ${gitLocation}${multiStoreProjects.papiros.folder}
   '';
-in mkIf (cfg.system.user.work.enable) {
+in mkIf (cfg.user.work.enable) {
   users.users.${username}.packages = with pkgs;
     [
       dbeaver # Database manager
@@ -65,9 +65,9 @@ in mkIf (cfg.system.user.work.enable) {
       php # Programming language for websites
       phpPackages.composer # Package manager for PHP
     ] ++ myPackages ++ shellScripts
-    ++ optional (cfg.system.user.work.httpd) apacheHttpd;
+    ++ optional (cfg.user.work.httpd) apacheHttpd;
 
-  services = mkIf (cfg.system.user.work.httpd) {
+  services = mkIf (cfg.user.work.httpd) {
     httpd = {
       enable = true;
       user = username;

--- a/system/desktop/default.nix
+++ b/system/desktop/default.nix
@@ -1,5 +1,10 @@
-# ## DESKTOP POWERED BY GNOME ###
-{ pkgs, config, lib, ... }: {
+{ pkgs, config, lib, ... }:
+
+let
+  inherit (lib) makeSearchPathOutput mkIf;
+
+  cfg = config.icedos;
+in {
   imports = [ ./home.nix ]; # Setup home manager
 
   # Set your time zone
@@ -17,17 +22,17 @@
 
       displayManager = {
         gdm = {
-          enable = config.desktop.gdm.enable;
-          autoSuspend = config.desktop.gdm.autoSuspend;
+          enable = cfg.desktop.gdm.enable;
+          autoSuspend = cfg.desktop.gdm.autoSuspend;
         };
 
-        autoLogin = lib.mkIf config.desktop.autologin.enable {
+        autoLogin = mkIf (cfg.desktop.autologin.enable) {
           enable = true;
-          user = if (config.system.user.main.enable
-            && config.desktop.autologin.main.user.enable) then
-            config.system.user.main.username
-          else if (config.system.user.work.enable) then
-            config.system.user.work.username
+          user = if (cfg.system.user.main.enable
+            && cfg.desktop.autologin.main.user.enable) then
+            cfg.system.user.main.username
+          else if (cfg.system.user.work.enable) then
+            cfg.system.user.work.username
           else
             "";
         };
@@ -77,8 +82,7 @@
       DEFAULT_BROWSER = "${pkgs.firefox}/bin/firefox";
       # Fix nautilus not displaying audio/video information in properties https://github.com/NixOS/nixpkgs/issues/53631
       GST_PLUGIN_SYSTEM_PATH_1_0 =
-        lib.makeSearchPathOutput "lib" "lib/gstreamer-1.0"
-        (with pkgs.gst_all_1; [
+        makeSearchPathOutput "lib" "lib/gstreamer-1.0" (with pkgs.gst_all_1; [
           gst-plugins-good
           gst-plugins-bad
           gst-plugins-ugly

--- a/system/desktop/gnome/default.nix
+++ b/system/desktop/gnome/default.nix
@@ -1,7 +1,10 @@
-# ## DESKTOP POWERED BY GNOME ###
 { pkgs, config, lib, ... }:
 
-{
+let
+  inherit (lib) mkIf optional;
+
+  cfg = config.icedos.desktop.gnome;
+in {
   imports = [
     # Setup home manager for gnome
     ./home.nix
@@ -9,13 +12,12 @@
     ./startup.nix
   ];
 
-  services.xserver.desktopManager.gnome.enable =
-    config.desktop.gnome.enable; # Install gnome
+  services.xserver.desktopManager.gnome.enable = cfg.enable; # Install gnome
 
-  programs.dconf.enable = lib.mkIf (config.desktop.gnome.enable) true;
+  programs.dconf.enable = mkIf (cfg.enable) true;
 
   environment.systemPackages = with pkgs;
-    (if (config.desktop.gnome.enable) then
+    (if (cfg.enable) then
       [
         gnome.dconf-editor # Edit gnome's dconf
         gnome.gnome-tweaks # Tweaks missing from pure gnome
@@ -23,17 +25,17 @@
         gnomeExtensions.pano # Next-gen Clipboard manager
         gnome-extension-manager # Gnome extensions manager and downloader
         gnomeExtensions.quick-settings-tweaker
-      ] ++ lib.optional config.desktop.gnome.extensions.arcmenu
-      gnomeExtensions.arcmenu # Start menu
-      ++ lib.optional config.desktop.gnome.extensions.dashToPanel
+      ]
+      ++ optional (cfg.extensions.arcmenu) gnomeExtensions.arcmenu # Start menu
+      ++ optional (cfg.extensions.dashToPanel)
       gnomeExtensions.dash-to-panel # An icon taskbar for gnome
-      ++ lib.optional config.desktop.gnome.extensions.gsconnect
+      ++ optional (cfg.extensions.gsconnect)
       gnomeExtensions.gsconnect # KDE Connect implementation for gnome
     else
       [ ]);
 
   environment.gnome.excludePackages = with pkgs;
-    lib.mkIf config.desktop.gnome.enable [
+    mkIf (cfg.enable) [
       epiphany # Web browser
       evince # Document viewer
       gnome-console # Terminal

--- a/system/desktop/gnome/startup.nix
+++ b/system/desktop/gnome/startup.nix
@@ -1,33 +1,36 @@
 { config, lib, ... }:
 
 let
+  inherit (lib) attrNames filter foldl' mkIf optional;
+
+  cfg = config.icedos;
+
   mapAttrsAndKeys = callback: list:
-    (lib.foldl' (acc: value: acc // (callback value)) { } list);
+    (foldl' (acc: value: acc // (callback value)) { } list);
 in {
   home-manager.users = let
-    users = lib.filter (user: config.system.user.${user}.enable == true)
-      (lib.attrNames config.system.user);
+    users = filter (user: cfg.system.user.${user}.enable == true)
+      (attrNames cfg.system.user);
   in mapAttrsAndKeys (user:
-    let username = config.system.user.${user}.username;
+    let username = cfg.system.user.${user}.username;
     in {
-      ${username}.home.file = lib.mkIf
-        (config.desktop.gnome.enable && config.desktop.gnome.startupItems) {
+      ${username}.home.file =
+        mkIf (cfg.desktop.gnome.enable && cfg.desktop.gnome.startupItems) {
           # Add signal to startup
-          ".config/autostart/signal-desktop.desktop" =
-            lib.mkIf (user != "work") {
-              text = ''
-                [Desktop Entry]
-                Exec=signal-desktop
-                Icon=signal
-                Name=Signal
-                StartupWMClass=signal
-                Terminal=false
-                Type=Application
-              '';
-            };
+          ".config/autostart/signal-desktop.desktop" = mkIf (user != "work") {
+            text = ''
+              [Desktop Entry]
+              Exec=signal-desktop
+              Icon=signal
+              Name=Signal
+              StartupWMClass=signal
+              Terminal=false
+              Type=Application
+            '';
+          };
 
           # Add steam to startup
-          ".config/autostart/steam.desktop" = lib.mkIf (user != "work") {
+          ".config/autostart/steam.desktop" = mkIf (user != "work") {
             text = ''
               [Desktop Entry]
               Exec=steam
@@ -39,7 +42,7 @@ in {
             '';
           };
 
-          ".config/autostart/slack.desktop" = lib.mkIf (user == "work") {
+          ".config/autostart/slack.desktop" = mkIf (user == "work") {
             text = ''
               [Desktop Entry]
               Exec=slack --enable-features=WaylandWindowDecorations

--- a/system/desktop/home.nix
+++ b/system/desktop/home.nix
@@ -1,13 +1,17 @@
 { config, pkgs, lib, ... }:
 let
+  inherit (lib) attrNames filter foldl' mkIf;
+
+  cfg = config.icedos;
+
   mapAttrsAndKeys = callback: list:
-    (lib.foldl' (acc: value: acc // (callback value)) { } list);
+    (foldl' (acc: value: acc // (callback value)) { } list);
 in {
   home-manager.users = let
-    users = lib.filter (user: config.system.user.${user}.enable == true)
-      (lib.attrNames config.system.user);
+    users = filter (user: cfg.system.user.${user}.enable == true)
+      (attrNames cfg.system.user);
   in mapAttrsAndKeys (user:
-    let username = config.system.user.${user}.username;
+    let username = cfg.system.user.${user}.username;
     in {
       ${username} = {
         gtk = {
@@ -39,7 +43,7 @@ in {
             # Codium profile used a an IDE
             codiumIDE = {
               exec =
-                "codium --user-data-dir ${config.system.home}/${username}/.config/VSCodiumIDE";
+                "codium --user-data-dir ${cfg.system.home}/${username}/.config/VSCodiumIDE";
               icon = "codium";
               name = "Codium IDE";
               terminal = false;
@@ -47,7 +51,7 @@ in {
             };
 
             # dbeaver on Xwayland (fix scaling issues)
-            dbeaver = lib.mkIf (user == "work") {
+            dbeaver = mkIf (user == "work") {
               exec = "env GDK_BACKEND=x11 dbeaver";
               icon = "dbeaver";
               name = "dbeaver - X11";
@@ -58,7 +62,7 @@ in {
             # Firefox PWA
             pwas = {
               exec =
-                "firefox --no-remote -P PWAs --name pwas ${config.applications.firefox.pwas.sites}";
+                "firefox --no-remote -P PWAs --name pwas ${cfg.applications.firefox.pwas.sites}";
               icon = "firefox-nightly";
               name = "Firefox PWAs";
               terminal = false;
@@ -75,7 +79,7 @@ in {
             };
 
             # Force slack to use window decorations
-            slack = lib.mkIf (user == "work") {
+            slack = mkIf (user == "work") {
               name = "Slack";
               exec = "slack --enable-features=WaylandWindowDecorations";
               icon = "slack";

--- a/system/desktop/hyprland/configs/hypridle.nix
+++ b/system/desktop/hyprland/configs/hypridle.nix
@@ -1,38 +1,41 @@
 { lib, config, ... }:
 
 let
-  mapAttrsAndKeys = callback: list:
-    (lib.foldl' (acc: value: acc // (callback value)) { } list);
+  inherit (lib) attrNames filter foldl';
 
+  cfg = config.icedos;
+
+  mapAttrsAndKeys = callback: list:
+    (foldl' (acc: value: acc // (callback value)) { } list);
 in {
   home-manager.users = let
-    users = lib.filter (user: config.system.user.${user}.enable == true)
-      (lib.attrNames config.system.user);
+    users = filter (user: cfg.system.user.${user}.enable == true)
+      (attrNames cfg.system.user);
   in mapAttrsAndKeys (user:
     let
-      username = config.system.user.${user}.username;
-      cfg = config.system.user.${user}.desktop.idle;
+      username = cfg.system.user.${user}.username;
+      idle = cfg.system.user.${user}.desktop.idle;
 
-      lock = if (cfg.lock.enable) then ''
+      lock = if (idle.lock.enable) then ''
         listener {
-            timeout = ${cfg.lock.seconds}
+            timeout = ${idle.lock.seconds}
             on-timeout = hyprlock-wrapper lock
         }
       '' else
         "";
 
-      disableMonitors = if (cfg.disableMonitors.enable) then ''
+      disableMonitors = if (idle.disableMonitors.enable) then ''
         listener {
-            timeout = ${cfg.disableMonitors.seconds}
+            timeout = ${idle.disableMonitors.seconds}
             on-timeout = hyprlock-wrapper off
             on-resume = hyprctl dispatch dpms on
         }
       '' else
         "";
 
-      suspend = if (cfg.suspend.enable) then ''
+      suspend = if (idle.suspend.enable) then ''
         listener {
-            timeout = ${cfg.suspend.seconds}
+            timeout = ${idle.suspend.seconds}
             on-timeout = hyprlock-wrapper suspend
         }
       '' else
@@ -47,7 +50,7 @@ in {
 
         # Lower brightness
         listener {
-            timeout = ${config.desktop.hyprland.lock.secondsToLowerBrightness}
+            timeout = ${cfg.desktop.hyprland.lock.secondsToLowerBrightness}
             on-timeout = brightnessctl -s set 10 && brightnessctl -sd rgb:kbd_backlight set 0
             on-resume = brightnessctl -r && brightnessctl -rd rgb:kbd_backlight
         }

--- a/system/desktop/hyprland/configs/swaync/config.nix
+++ b/system/desktop/hyprland/configs/swaync/config.nix
@@ -1,22 +1,26 @@
 { config, lib, ... }:
 let
-  mapAttrsAndKeys = callback: list:
-    (lib.foldl' (acc: value: acc // (callback value)) { } list);
+  inherit (lib) attrNames filter foldl';
 
-  workspace = if (config.hardware.monitors.main.enable
-    && config.hardware.monitors.secondary.enable) then
+  cfg = config.icedos;
+
+  mapAttrsAndKeys = callback: list:
+    (foldl' (acc: value: acc // (callback value)) { } list);
+
+  workspace = if (cfg.hardware.monitors.main.enable
+    && cfg.hardware.monitors.secondary.enable) then
     "11"
   else
     "3";
 in {
   home-manager.users = let
-    users = lib.filter (user: config.system.user.${user}.enable == true)
-      (lib.attrNames config.system.user);
+    users = filter (user: cfg.system.user.${user}.enable == true)
+      (attrNames cfg.system.user);
   in mapAttrsAndKeys (user:
-    let username = config.system.user.${user}.username;
+    let username = cfg.system.user.${user}.username;
     in {
       ${username}.home.file = {
-        ".config/swaync/config.json".text = ''
+        ".config/swaync/cfg.json".text = ''
           {
             "scripts": {
               "messengers": {

--- a/system/desktop/hyprland/configs/waybar/config.nix
+++ b/system/desktop/hyprland/configs/waybar/config.nix
@@ -1,16 +1,20 @@
 { pkgs, lib, config, ... }:
 let
+  inherit (lib) attrNames filter foldl';
+
+  cfg = config.icedos;
+
   mapAttrsAndKeys = callback: list:
-    (lib.foldl' (acc: value: acc // (callback value)) { } list);
+    (foldl' (acc: value: acc // (callback value)) { } list);
 
   vpn-toggle = import modules/vpn-watcher.nix { inherit pkgs; };
   vpn-watcher = import modules/vpn-toggle.nix { inherit pkgs; };
 in {
   home-manager.users = let
-    users = lib.filter (user: config.system.user.${user}.enable == true)
-      (lib.attrNames config.system.user);
+    users = filter (user: cfg.system.user.${user}.enable == true)
+      (attrNames cfg.system.user);
   in mapAttrsAndKeys (user:
-    let username = config.system.user.${user}.username;
+    let username = cfg.system.user.${user}.username;
     in {
       ${username}.home = {
         packages = with pkgs; [ vpn-toggle vpn-watcher psmisc ];

--- a/system/desktop/hyprland/default.nix
+++ b/system/desktop/hyprland/default.nix
@@ -1,6 +1,10 @@
 { pkgs, config, lib, inputs, ... }:
 
 let
+  inherit (lib) mkIf;
+
+  cfg = config.icedos;
+
   cpu-watcher = import modules/cpu-watcher.nix {
     pkgs = pkgs;
     config = config;
@@ -20,7 +24,6 @@ let
 
   hyprlock-wrapper = import modules/hyprlock-wrapper.nix { pkgs = pkgs; };
 
-  cfg = config.desktop.hyprland;
 in {
   imports = [
     ./configs/config.nix
@@ -30,13 +33,13 @@ in {
     ./home.nix
   ];
 
-  programs = lib.mkIf (cfg.enable) {
+  programs = mkIf (cfg.desktop.hyprland.enable) {
     nm-applet.enable = true; # Network manager tray icon
     kdeconnect.enable = true; # Connect phone to PC
     hyprland.enable = true;
   };
 
-  environment = lib.mkIf (cfg.enable) {
+  environment = mkIf (cfg.desktop.hyprland.enable) {
     systemPackages = with pkgs; [
       baobab # Disk usage analyser
       brightnessctl # Brightness control
@@ -83,7 +86,7 @@ in {
       wlogout # Logout screen
     ];
 
-    etc = lib.mkIf (cfg.enable) {
+    etc = mkIf (cfg.desktop.hyprland.enable) {
       "polkit-gnome".source =
         "${pkgs.polkit_gnome}/libexec/polkit-gnome-authentication-agent-1";
       "kdeconnectd".source =
@@ -92,18 +95,18 @@ in {
     };
   };
 
-  services = lib.mkIf (cfg.enable) {
+  services = mkIf (cfg.desktop.hyprland.enable) {
     dbus.enable = true;
     gvfs.enable = true; # Needed for nautilus
     gnome.gnome-keyring.enable = true;
   };
 
-  security = lib.mkIf (cfg.enable) {
+  security = mkIf (cfg.desktop.hyprland.enable) {
     polkit.enable = true;
     pam.services.login.enableGnomeKeyring = true;
   };
 
-  systemd.services.swayosd-input = lib.mkIf (cfg.enable) {
+  systemd.services.swayosd-input = mkIf (cfg.desktop.hyprland.enable) {
     enable = true;
     description =
       "SwayOSD LibInput backend for listening to certain keys like CapsLock, ScrollLock, VolumeUp, etc...";
@@ -126,10 +129,10 @@ in {
   };
 
   xdg.portal.extraPortals =
-    lib.mkIf (!config.desktop.gnome.enable && cfg.enable)
+    mkIf (!cfg.desktop.gnome.enable && cfg.desktop.hyprland.enable)
     [ pkgs.xdg-desktop-portal-gtk ]; # Needed for steam file picker
 
-  nix.settings = lib.mkIf (cfg.enable) {
+  nix.settings = mkIf (cfg.desktop.hyprland.enable) {
     substituters = [ "https://hyprland.cachix.org" ];
     trusted-public-keys =
       [ "hyprland.cachix.org-1:a7pgxzMz7+chwVL3/pzj6jIBMioiJM7ypFP8PwtkuGc=" ];

--- a/system/desktop/hyprland/home.nix
+++ b/system/desktop/hyprland/home.nix
@@ -1,17 +1,20 @@
 { config, lib, ... }:
 
 let
+  inherit (lib) attrNames filter foldl' mkIf;
+
+  cfg = config.icedos;
+
   mapAttrsAndKeys = callback: list:
-    (lib.foldl' (acc: value: acc // (callback value)) { } list);
-  cfg = config.desktop.hyprland;
+    (foldl' (acc: value: acc // (callback value)) { } list);
 in {
   home-manager.users = let
-    users = lib.filter (user: config.system.user.${user}.enable == true)
-      (lib.attrNames config.system.user);
+    users = filter (user: cfg.system.user.${user}.enable == true)
+      (attrNames cfg.system.user);
   in mapAttrsAndKeys (user:
-    let username = config.system.user.${user}.username;
+    let username = cfg.system.user.${user}.username;
     in {
-      ${username} = lib.mkIf (cfg.enable) {
+      ${username} = mkIf (cfg.desktop.hyprland.enable) {
         # Gnome control center running in Hypr WMs
         xdg.desktopEntries.gnome-control-center = {
           exec = "env XDG_CURRENT_DESKTOP=GNOME gnome-control-center";

--- a/system/desktop/hyprland/modules/cpu-watcher.nix
+++ b/system/desktop/hyprland/modules/cpu-watcher.nix
@@ -1,5 +1,7 @@
 { pkgs, config }:
-let threshold = config.desktop.hyprland.lock.cpuUsageThreshold;
+let
+  cfg = config.icedos;
+  threshold = cfg.desktop.hyprland.lock.cpuUsageThreshold;
 in pkgs.writeShellScriptBin "cpu-watcher" ''
   UTILIZATION="$((100-$(vmstat 1 2|tail -1|awk '{print $15}')))"
   CPU_THRESOLD=${threshold}

--- a/system/desktop/hyprland/modules/disk-watcher.nix
+++ b/system/desktop/hyprland/modules/disk-watcher.nix
@@ -1,5 +1,7 @@
 { pkgs, config }:
-let threshold = config.desktop.hyprland.lock.diskUsageThreshold;
+let
+  cfg = config.icedos;
+  threshold = cfg.desktop.hyprland.lock.diskUsageThreshold;
 in pkgs.writeShellScriptBin "disk-watcher" ''
   DISKS=($(lsblk -d -io NAME | tail -n +2))
   READ_QUERY=".sysstat.hosts[].statistics[].disk[].MB_read"

--- a/system/desktop/hyprland/modules/network-watcher.nix
+++ b/system/desktop/hyprland/modules/network-watcher.nix
@@ -1,5 +1,7 @@
 { pkgs, config }:
-let threshold = config.desktop.hyprland.lock.networkUsageThreshold;
+let
+  cfg = config.icedos;
+  threshold = cfg.desktop.hyprland.lock.networkUsageThreshold;
 in pkgs.writeShellScriptBin "network-watcher" ''
   NETWORK_THRESHOLD=${threshold}
   INTERFACE=$(ip route | head -n 1 | grep -oP 'dev \K\S+')

--- a/system/desktop/steam-session/default.nix
+++ b/system/desktop/steam-session/default.nix
@@ -1,28 +1,31 @@
 { config, lib, ... }:
 
 let
-  cfg = config.applications.steam.session;
-  steamUser = config.system.user.main.username;
-  hasAmdGpu = config.hardware.gpu.amd;
+  inherit (lib) mkIf;
+
+  cfg = config.icedos;
+  session = cfg.applications.steam.session;
+  steamUser = cfg.system.user.main.username;
+  hasAmdGpu = cfg.hardware.gpu.amd;
 in {
   jovian = {
-    decky-loader.enable = (cfg.enable && cfg.decky);
+    decky-loader.enable = (session.enable && session.decky);
 
-    devices.steamdeck = lib.mkIf (cfg.enable && cfg.steamdeck) {
+    devices.steamdeck = mkIf (session.enable && session.steamdeck) {
       enable = true;
       enableGyroDsuService = true;
       autoUpdate = true;
     };
 
-    steam = lib.mkIf cfg.enable {
+    steam = mkIf (session.enable) {
       enable = true;
-      autoStart = cfg.autoStart.enable;
-      desktopSession = cfg.autoStart.desktopSession;
+      autoStart = session.autoStart.enable;
+      desktopSession = session.autoStart.desktopSession;
       user = steamUser;
     };
 
-    hardware.has.amd.gpu = (cfg.enable && hasAmdGpu);
+    hardware.has.amd.gpu = (session.enable && hasAmdGpu);
 
-    steamos.useSteamOSConfig = cfg.enable;
+    steamos.useSteamOSConfig = session.enable;
   };
 }


### PR DESCRIPTION
This PR will:

- Nest the custom .nix config in an extra `icedos` key, to separate it from the native nixos config, as you now will need to do `config.icedos.{...}` to access the custom configuration, preventing key naming collisions.

- Remove a lot of usages of the unsafe `with` keyword, which allows access to all functions in a namespace by using their name directly, and replace it with a simple destructuring call using `inherit`, only declaring the functions each module uses.