### PR TITLE
Use new nvtop naming scheme

### DIFF
--- a/hardware/amd/radeon.nix
+++ b/hardware/amd/radeon.nix
@@ -12,7 +12,7 @@ in mkIf (cfg) {
   };
 
   environment.systemPackages = with pkgs; [
-    nvtop-amd # GPU task manager
+    nvtopPackages.amd # GPU task manager
     lact # GPU overclocking tool
   ];
 

--- a/hardware/nvidia.nix
+++ b/hardware/nvidia.nix
@@ -22,7 +22,7 @@ in mkIf (cfg.hardware.gpu.nvidia.enable) {
     cfg.hardware.virtualisation.docker; # Enable nvidia gpu acceleration for docker
 
   environment.systemPackages =
-    [ pkgs.nvtop-nvidia ] # Monitoring tool for nvidia GPUs
+    [ pkgs.nvtopPackages.nvidia ] # Monitoring tool for nvidia GPUs
     ++ optional (cfg.hardware.laptop.enable)
     nvidia-offload; # Use nvidia-offload to launch programs using the nvidia GPU
 


### PR DESCRIPTION
Fixes the following warning when running rebuild/update `trace: warning: nvtop-amd has been renamed to nvtopPackages.amd`.