### PR TITLE
Remove unnecessary sound option

### DIFF
--- a/system/desktop/default.nix
+++ b/system/desktop/default.nix
@@ -60,7 +60,6 @@ in
     "autovt@tty1".enable = false;
   };
 
-  sound.enable = true;
   hardware.pulseaudio.enable = false;
   security.rtkit.enable = true; # Enable service which hands out realtime scheduling priority to user processes on demand, required by pipewire
 


### PR DESCRIPTION
Building gives the following error, so this PR follows its instructions.

`The option definition 'sound' in '/nix/store/...-source/system/desktop' no longer has any effect; please remove it. The option was heavily overloaded and can be removed from most configurations.`