### PR TITLE
wayland: remove unnecessary cli options

### DIFF
--- a/system/applications/modules/brave.nix
+++ b/system/applications/modules/brave.nix
@@ -7,37 +7,11 @@
 
 let
   inherit (lib)
-    attrNames
-    filter
-    foldl'
     mkIf
     ;
 
   cfg = config.icedos;
-
-  mapAttrsAndKeys = callback: list: (foldl' (acc: value: acc // (callback value)) { } list);
 in
 mkIf (cfg.applications.brave) {
   environment.systemPackages = [ pkgs.brave ];
-
-  home-manager.users =
-    let
-      users = filter (user: cfg.system.users.${user}.enable == true) (attrNames cfg.system.users);
-    in
-    mapAttrsAndKeys (
-      user:
-      let
-        username = cfg.system.users.${user}.username;
-      in
-      {
-        # Enable wayland support for brave
-        ${username}.xdg.desktopEntries.brave-browser = {
-          exec = "brave --enable-features=UseOzonePlatform --ozone-platform=wayland";
-          icon = "brave";
-          name = "Brave";
-          terminal = false;
-          type = "Application";
-        };
-      }
-    ) users;
 }

--- a/system/applications/modules/codium/default.nix
+++ b/system/applications/modules/codium/default.nix
@@ -44,15 +44,6 @@ in
       in
       {
         ${username} = mkIf (cfg.applications.codium.enable) {
-          # Codium profile used as a multi-purpose text editor
-          xdg.desktopEntries.codium = {
-            exec = "codium";
-            icon = "codium";
-            name = "VSCodium";
-            terminal = false;
-            type = "Application";
-          };
-
           # Codium profile used as an IDE
           xdg.desktopEntries.codiumIDE = {
             exec = "codium --user-data-dir ${cfg.system.home}/${username}/.config/VSCodiumIDE";

--- a/system/applications/modules/codium/default.nix
+++ b/system/applications/modules/codium/default.nix
@@ -44,18 +44,18 @@ in
       in
       {
         ${username} = mkIf (cfg.applications.codium.enable) {
-          # Enable wayland support for codium
+          # Codium profile used as a multi-purpose text editor
           xdg.desktopEntries.codium = {
-            exec = "codium --enable-features=UseOzonePlatform --ozone-platform=wayland";
+            exec = "codium";
             icon = "codium";
             name = "VSCodium";
             terminal = false;
             type = "Application";
           };
 
-          # Codium profile used a an IDE
+          # Codium profile used as an IDE
           xdg.desktopEntries.codiumIDE = {
-            exec = "codium --user-data-dir ${cfg.system.home}/${username}/.config/VSCodiumIDE --enable-features=UseOzonePlatform --ozone-platform=wayland";
+            exec = "codium --user-data-dir ${cfg.system.home}/${username}/.config/VSCodiumIDE";
             icon = "codium";
             name = "VSCodium IDE";
             terminal = false;


### PR DESCRIPTION
The following warnings show up, when opening codium through the cli, or updating the codium plugins:

```
Warning: 'ozone-platform-hint' is not in the list of known options, but still passed to Electron/Chromium.
Warning: 'enable-features' is not in the list of known options, but still passed to Electron/Chromium.
```

This is due to [this](https://github.com/IceDBorn/IceDOS/commit/1d61c6c0b22724ec36970b0dfe0d0a0e273737b8) commit, which supposedly means we can stop adding the wayland flags to individual apps.

More info [here](https://github.com/NixOS/nixpkgs/issues/271461) and [here](https://github.com/NixOS/nixpkgs/pull/262343).

Can you also test if the flags can be removed from the Brave module?