### PR TITLE
hardware: rtl8821ce

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -203,6 +203,7 @@ laptop = false
 steamdeck = false
 
 [icedos.hardware.drivers]
+rtl8821ce = false # Use the unofficial RTL8821CE driver
 xpadneo = true # Xbox gamepad bluetooth driver (supports various xinput controllers)
 
 [icedos.hardware.devices.server]

--- a/options.nix
+++ b/options.nix
@@ -224,7 +224,10 @@
           steamdeck = mkOption { type = types.bool; };
         };
 
-        drivers.xpadneo = mkOption { type = types.bool; };
+        drivers = {
+          rtl8821ce = mkOption { type = types.bool; };
+          xpadneo = mkOption { type = types.bool; };
+        };
 
         gpus = {
           amd = {

--- a/system/applications/default.nix
+++ b/system/applications/default.nix
@@ -73,6 +73,7 @@ in
     ./modules/mullvad.nix
     ./modules/php.nix
     ./modules/pitivi.nix
+    ./modules/rtl8821ce.nix
     ./modules/rust.nix
     ./modules/solaar.nix
     ./modules/steam.nix

--- a/system/applications/modules/rtl8821ce.nix
+++ b/system/applications/modules/rtl8821ce.nix
@@ -1,0 +1,12 @@
+{ config, lib, ... }:
+
+let
+  inherit (lib) mkIf;
+  cfg = config.icedos.hardware.drivers.rtl8821ce;
+in mkIf cfg {
+  boot = {
+    extraModulePackages = with config.boot.kernelPackages; [ rtl8821ce ];
+    blacklistedKernelModules = [ "rtw88_8821ce" ];
+    kernelModules = [ "rtl8821ce" ];
+  };
+}


### PR DESCRIPTION
The official driver from Realtek (aka rtw88) is known to cause issues with this specific wifi module.
It's recommended to use [this driver](https://github.com/tomaspinho/rtl8821ce) instead.