### PR TITLE
Symlink self to current-system

### DIFF
--- a/system/applications/default.nix
+++ b/system/applications/default.nix
@@ -97,4 +97,7 @@ in
     openssh.enable = true;
     fwupd.enable = true;
   };
+
+  # Source: https://github.com/NixOS/nixpkgs/blob/5e4fbfb6b3de1aa2872b76d49fafc942626e2add/nixos/modules/system/activation/top-level.nix#L191
+  system.extraSystemBuilderCmds = "ln -s ${inputs.self} $out/source";
 }


### PR DESCRIPTION
Add a symlink to `/run/current-system/source`, pointing to the code used for that build. Typically this is done with `system.copySystemConfiguration`, but it's not supported in flakes.