### PR TITLE
rebuild: add arguments

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -5,6 +5,28 @@ EXTRAS="/etc/nixos/extras.nix"
 CONFIG="/tmp/configuration-location"
 FLAKE="flake.nix"
 
+action="switch"
+extraBuildArgs=()
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --boot)
+      action="boot"
+      shift
+      ;;
+    --builder)
+      extraBuildArgs+=("--build-host")
+      extraBuildArgs+=("$2")
+      shift
+      shift
+      ;;
+    *)
+      echo "Unknown arg $1" >/dev/stderr
+      exit 1
+      ;;
+  esac
+done
+
 [ ! -f "$EXTRAS" ] && echo "{}" | tee "$EXTRAS" > /dev/null
 
 # Save current directory into a file
@@ -17,4 +39,4 @@ nix eval --extra-experimental-features nix-command --write-to "$FLAKE" --file "g
 nixfmt "$FLAKE"
 
 # Build the system configuration
-nixos-rebuild switch --show-trace --impure --flake .#"$(cat /etc/hostname)"
+nixos-rebuild $action --show-trace --impure --flake .#"$(cat /etc/hostname)" ${extraBuildArgs[*]}

--- a/system/applications/modules/rebuild/default.nix
+++ b/system/applications/modules/rebuild/default.nix
@@ -34,10 +34,10 @@ pkgs.writeShellScriptBin "${command}" ''
 
   if ${update}; then
   	nix flake update && cache "flake.lock" || true
-  	sudo nix-shell scripts/build.sh
+  	sudo nix-shell scripts/build.sh $@
 
   	runCommand update-codium-extensions
   else
-  	sudo bash scripts/build.sh
+  	sudo bash scripts/build.sh $@
   fi
 ''

--- a/system/applications/modules/rebuild/default.nix
+++ b/system/applications/modules/rebuild/default.nix
@@ -38,6 +38,6 @@ pkgs.writeShellScriptBin "${command}" ''
 
   	runCommand update-codium-extensions
   else
-  	sudo bash scripts/build.sh $@
+  	sudo nix-shell scripts/build.sh $@
   fi
 ''

--- a/system/applications/modules/rebuild/default.nix
+++ b/system/applications/modules/rebuild/default.nix
@@ -6,21 +6,21 @@
 }:
 pkgs.writeShellScriptBin "${command}" ''
   function cache() {
-  	FILE="$1"
+    FILE="$1"
 
-  	[ ! -f "$FILE" ] && exit 1
-  	mkdir -p .cache
+    [ ! -f "$FILE" ] && exit 1
+    mkdir -p .cache
 
-  	LASTFILE=$(ls -lt ".cache" | grep "$FILE" | head -2 | tail -1 | awk '{print $9}')
+    LASTFILE=$(ls -lt ".cache" | grep "$FILE" | head -2 | tail -1 | awk '{print $9}')
 
-  	diff -sq ".cache/$LASTFILE" "$FILE" &> /dev/null || cp "$FILE" ".cache/$FILE-$(date -Is)"
+    diff -sq ".cache/$LASTFILE" "$FILE" &> /dev/null || cp "$FILE" ".cache/$FILE-$(date -Is)"
   }
 
   function runCommand() {
-  	if command -v "$1" &> /dev/null
-  	then
-  		"$1"
-  	fi
+    if command -v "$1" &> /dev/null
+    then
+      "$1"
+    fi
   }
 
   # Retain sudo
@@ -33,11 +33,11 @@ pkgs.writeShellScriptBin "${command}" ''
   cache "flake.nix"
 
   if ${update}; then
-  	nix flake update && cache "flake.lock" || true
-  	sudo nix-shell scripts/build.sh $@
+    nix flake update && cache "flake.lock" || true
+    sudo nix-shell scripts/build.sh $@
 
-  	runCommand update-codium-extensions
+    runCommand update-codium-extensions
   else
-  	sudo nix-shell scripts/build.sh $@
+    sudo nix-shell scripts/build.sh $@
   fi
 ''


### PR DESCRIPTION
Add the following arguments to `rebuild`:

- `--boot`: runs `nixos-rebuild --boot` instead of `nixos-rebuild --switch`
- `--builder $host`: adds the `--build-host $host` argument to `nixos-rebuild`