### PR TITLE
celluloid: fix hdr not being properly enabled

### DIFF
--- a/system/applications/modules/celluloid/config/celluloid.conf
+++ b/system/applications/modules/celluloid/config/celluloid.conf
@@ -19,10 +19,10 @@ target-colorspace-hint=yes
 
 [HDR] # Dolby Video HDR profile
 profile-restore=copy
-target-trc=pq
+# target-trc=pq # Isn't supported properly by most WMs and DEs, but will greatly improve color and brightness when it is
 target-prim=bt.2020
 # Adjust this to the peak brightness of your display
-target-peak=1000
+target-peak=400
 
 # Prefer Japanese audio when available (for anime)
 alang=Japanese,jpn,ja,English,eng,en

--- a/system/applications/modules/celluloid/default.nix
+++ b/system/applications/modules/celluloid/default.nix
@@ -11,7 +11,7 @@ let
 in
 mkIf (cfg.applications.celluloid) {
   environment.systemPackages = with pkgs; [
-    (writeShellScriptBin "celluloid-hdr" "celluloid --mpv-profile=HDR $@")
+    (writeShellScriptBin "celluloid-hdr" "ENABLE_HDR_WSI=1 celluloid --mpv-profile=HDR $@")
     celluloid
   ];
 


### PR DESCRIPTION
[This comment](https://gitlab.gnome.org/GNOME/mutter/-/issues/3681#note_2311067) mentions that we need to do `ENABLE_HDR_WSI=1` to actually enable HDR for celluloid, so I tried it and it worked, so the command also finally works now.

Also, since most displays only support 400 nits peak, I lowered it to that. 

Finally, I learned that PQ is completely broken right now (at least on GNOME), so I also disabled it by default.