### PR TITLE
hyprland: implement monitor disabling + fix rotation

### DIFF
--- a/options.nix
+++ b/options.nix
@@ -279,6 +279,7 @@
             types.submodule {
               options = {
                 name = mkOption { type = types.str; };
+                disable = mkOption { type = types.bool; default = false; };
                 resolution = mkOption { type = types.str; };
                 refreshRate = mkOption { type = types.number; };
                 position = mkOption { type = types.str; };


### PR DESCRIPTION
Since Hyprland automatically uses all detected monitors, the `disable` option allows the user to explicitly tell Hyprland not to use that monitor.