### PR TITLE
thunar: init

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -80,6 +80,9 @@ desktopSession = "hyprland"
 enable = true
 enableTrayscale = true
 
+[icedos.applications.thunar]
+enable = false
+
 [icedos.applications.valent]
 enable = false
 deviceId = "901524a4_c7c0_407e_9903_431abce54131"

--- a/internals.nix
+++ b/internals.nix
@@ -31,5 +31,15 @@ in
     };
 
     isFirstBuild = mkOption { type = types.bool; };
+
+    xfce4.files = mkOption {
+      type = with types; attrsOf (submodule {
+        options = {
+          source = mkOption { default = null; };
+          text = mkOption { default = null; };
+        };
+      });
+      default = {};
+    };
   };
 }

--- a/options.nix
+++ b/options.nix
@@ -97,6 +97,11 @@
           enableTrayscale = mkOption { type = types.bool; };
         };
 
+        thunar = {
+          enable = mkOption { type = types.bool; };
+          targetServers = mkOption { type = with types; listOf str; };
+        };
+
         valent = {
           enable = mkOption { type = types.bool; };
           deviceId = mkOption { type = types.str; };

--- a/system/applications/modules/thunar/default.nix
+++ b/system/applications/modules/thunar/default.nix
@@ -1,0 +1,25 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  inherit (lib) mapAttrs mkIf;
+  cfg = config.icedos;
+in
+mkIf (cfg.applications.thunar.enable) {
+  programs.thunar = {
+    enable = true;
+    plugins = with pkgs.xfce; [
+      thunar-archive-plugin # Create/Extract archives
+      thunar-volman # Removable media management
+      tumbler # Media files thumbnails
+    ];
+  };
+
+  icedos.internals.xfce4.files = {
+    "xfconf/xfce-perchannel-xml/thunar.xml".source = ./thunar.xml;
+  };
+}

--- a/system/applications/modules/thunar/thunar.xml
+++ b/system/applications/modules/thunar/thunar.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<channel name="thunar" version="1.0">
+  <property name="last-show-hidden" type="bool" value="true"/>
+  <property name="last-sort-column" type="string" value="THUNAR_COLUMN_NAME"/>
+  <property name="last-sort-order" type="string" value="GTK_SORT_ASCENDING"/>
+  <property name="last-view" type="string" value="ThunarIconView"/>
+  <property name="misc-middle-click-in-tab" type="bool" value="true"/>
+</channel>

--- a/system/applications/modules/xfce4/default.nix
+++ b/system/applications/modules/xfce4/default.nix
@@ -1,0 +1,55 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  inherit (builtins) toJSON;
+  inherit (lib) attrNames baseNameOf concatStrings isPath isString length map mapAttrs mkIf xor;
+  cfg = config.icedos;
+
+  files = cfg.internals.xfce4.files;
+  fileNames = attrNames files;
+  filesExist = length fileNames > 0;
+
+  xfce4FilesScript =
+    map
+    (file: ''
+      mkdir -p $out/$(dirname "${file}")
+      ${
+        if (files.${file}.source == null)
+        then "ln -s ${with builtins; toFile (baseNameOf file) files.${file}.text} ${file}"
+        else "ln -s ${files.${file}.source} ${file}"
+      }
+    '')
+    fileNames;
+
+  xfce4Files = pkgs.runCommand "xfce4Files" {} ''
+    mkdir -p $out ; cd $out
+    ${concatStrings xfce4FilesScript}
+  '';
+in
+mkIf (filesExist) {
+  assertions = map
+    (file:
+      let
+        inherit (files.${file}) source text;
+      in {
+        assertion = (xor (source != null) (text != null)) && ((isPath source) || (isString text));
+        message = ''
+          Please set only "${file}".source to a file path, or "${file}".text to a string.
+          Current value: ${toJSON files.${file}}.
+        '';
+      })
+    fileNames;
+
+  home-manager.users = mapAttrs (user: _: {
+    home.file = mkIf (cfg.system.users.${user}.type != "server") {
+      ".config/xfce4" = {
+        source = xfce4Files;
+      };
+    };
+  }) cfg.system.users;
+}


### PR DESCRIPTION
This PR adds the Thunar file manager and a module that manages XFCE4 configurations.

Standard home-manager way does not work as `thunar` runs `xfconfd` in the background, which overwrites existing config files and causes errors to home-manager.

The xfce4 module is responsible for collecting all xfce-related files, which are configured using the new internal `icedos.internals.xfce4.files` option, and adds them to a derivation. This derivation is passed to home-manager, ensuring that the entire `~/.config/xfce4` directory is read-only, preventing `xfconfd` from modifying the files.

Pending:
- [ ] Custom actions
- [ ] Integration with servers