### PR TITLE
virt-manager: enable pcie passthrough

### DIFF
--- a/system/applications/modules/virt-manager/default.nix
+++ b/system/applications/modules/virt-manager/default.nix
@@ -6,6 +6,7 @@
 
 let
   inherit (lib) mapAttrs mkIf;
+  inherit (config.icedos.hardware) cpus;
   cfg = config.icedos.system;
 in
 mkIf (cfg.virtualisation.virtManager) {
@@ -19,4 +20,17 @@ mkIf (cfg.virtualisation.virtManager) {
   users.users = mapAttrs (user: _: {
     extraGroups = [ "libvirtd" ];
   }) cfg.users;
+
+  boot.kernelParams = [
+    # Allows passthrough of independent devices, that are members of larger IOMMU groups
+    # It only affects kernels with ACS Override support. Ex: CachyOS, Liquorix, Zen
+    "pcie_acs_override=downstream,multifunction"
+  ] ++ (
+      # Enable PCIe passthrough
+      if (cpus.amd.enable)
+      then [ "amd_iommu=on" ]
+      else if (cpus.intel)
+      then [ "intel_iommu=on" ]
+      else []
+  );
 }

--- a/system/applications/modules/virt-manager/default.nix
+++ b/system/applications/modules/virt-manager/default.nix
@@ -5,7 +5,7 @@
 }:
 
 let
-  inherit (lib) mapAttrs mkIf;
+  inherit (lib) mapAttrs mkIf optional;
   inherit (config.icedos.hardware) cpus;
   cfg = config.icedos.system;
 in
@@ -25,12 +25,7 @@ mkIf (cfg.virtualisation.virtManager) {
     # Allows passthrough of independent devices, that are members of larger IOMMU groups
     # It only affects kernels with ACS Override support. Ex: CachyOS, Liquorix, Zen
     "pcie_acs_override=downstream,multifunction"
-  ] ++ (
-      # Enable PCIe passthrough
-      if (cpus.amd.enable)
-      then [ "amd_iommu=on" ]
-      else if (cpus.intel)
-      then [ "intel_iommu=on" ]
-      else []
-  );
+  ]
+    ++ optional cpus.amd.enable "amd_iommu=on"
+    ++ optional cpus.intel "intel_iommu=on";
 }


### PR DESCRIPTION
- `pcie_acs_override=downstream,multifunction`: Enables pass-through of any PCIe device, by leveraging ACS Override on supported kernels.
More info about the initial patch: https://lkml.org/lkml/2013/5/30/513
Kernels that known to use this patch: CachyOS, Liquorix and Zen
- `amd_iommu=on`: Enables PCIe pass-through on AMD CPUs
- `intel_iommu=on`: Enables PCIe pass-through on Intel CPUs